### PR TITLE
fix(scanner): use local include

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,6 +1,6 @@
 #include "stdio.h"
 #include "stdlib.h"
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 #include <string.h>
 #include <wctype.h>
 #include <assert.h>


### PR DESCRIPTION
tree-sitter CLI no longer installs the header globally

closes #12
