### PR TITLE
Make rust binding really useful

### DIFF
--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -35,8 +35,12 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+/// The syntax highlighting query for this language.
+pub const HIGHLIGHT_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+
+/// The injections query for this language.
+pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+
 // pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
 


### PR DESCRIPTION
Perhaps I'm the first one to use the Rust binding of tree-sitter-vim :P This commit uncomments the available queries so that it is really usable.

`HIGHLIGHT_QUERY` follows the convention of other Rust bindings.